### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/lookup.R
+++ b/R/lookup.R
@@ -53,7 +53,7 @@ lookup <- function(key = auth_cache$KEY, lsPublisherId = NULL, id = NULL, upc = 
     url <- glue::glue("{url}&lsPublisherId={lsPublisherId}")
   }
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)

--- a/R/paginated.R
+++ b/R/paginated.R
@@ -57,7 +57,7 @@ paginted <- function(key = auth_cache$KEY, lsPublisherId = NULL,
     url <- glue::glue("{url}&lsPublisherId={lsPublisherId}")
   }
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)

--- a/R/search.R
+++ b/R/search.R
@@ -94,7 +94,7 @@ searching <- function(query, key = auth_cache$KEY, lsPublisherId = NULL,
     url <- glue::glue("{url}&lsPublisherId={lsPublisherId}")
   }
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)

--- a/R/store_locator.R
+++ b/R/store_locator.R
@@ -51,7 +51,7 @@ store_locator <- function(key = auth_cache$KEY, lat = NULL, lon = NULL,
     url <- glue::glue("{base_url}&lon={lon}&lat={lat}")
   }
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -31,7 +31,7 @@ taxonomy <- function(key = auth_cache$KEY, list_output = FALSE) {
 
   url <- glue::glue("http://api.walmartlabs.com/v1/taxonomy?apiKey={key}")
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)

--- a/R/trending.R
+++ b/R/trending.R
@@ -37,7 +37,7 @@ trending <- function(key = auth_cache$KEY, lsPublisherId = NULL,
     url <- glue::glue("{url}&lsPublisherId={lsPublisherId}")
   }
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)

--- a/R/vod.R
+++ b/R/vod.R
@@ -27,7 +27,7 @@ VOD <- function(key = auth_cache$KEY, list_output = FALSE) {
 
   url <- glue::glue("http://api.walmartlabs.com/v1/vod?format=json&apiKey={key}")
 
-  response <- httr::GET(url)
+  response <- httr::RETRY(verb = "GET", url)
 
   if (httr::http_type(response) != "application/json") {
     stop("API did not return json", call. = FALSE)


### PR DESCRIPTION
Thanks for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.